### PR TITLE
add string array type to mapping

### DIFF
--- a/types/template.ts
+++ b/types/template.ts
@@ -8,7 +8,7 @@ export default interface Template {
     Description?: string
     Metadata?: { [key: string]: any }
     Parameters?: { [key: string]: Parameter }
-    Mappings?: { [key: string]: { [key: string]: { [key: string]: string | number } } }
+    Mappings?: { [key: string]: { [key: string]: { [key: string]: string | number | string[] } } }
     Conditions?: { [key: string]: Condition }
     Transform?: any
     Resources?: { [key: string]: Resource }


### PR DESCRIPTION
for use case like 
```
  Mappings: {
    dev: {
      'us-east-1': {
        'InstanceType': 't2.micro',
        'SecurityGroupIds': ['sg-5a5ee027', 'sg-c0c5eab8', 'sg-42e70f24'],
        'SubnetId': 'subnet-3fd04c49'
      }
    }
  },
```

*string array* is needed so that it can be set in the `resource` section .

```
Resources: {
    testECSInstance: new EC2.Instance({
      ImageId: Fn.Ref('ImageId'),
      InstanceType: Fn.FindInMap(Fn.Ref('Environment'), Refs.Region, 'InstanceType'),
      SecurityGroupIds: Fn.FindInMap(Fn.Ref('Environment'), Refs.Region, 'SecurityGroupIds'),
      SubnetId: Fn.FindInMap(Fn.Ref('Environment'), Refs.Region, 'SubnetId'),
}
```

`Cloudform` is great. Thanks for sharing!