### PR TITLE
Use ts-node when evaluating template file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TypeScript-based imperative way to define AWS CloudFormation templates
 ```typescript
 import cloudform, {Fn, Refs, EC2, StringParameter, ResourceTag} from "cloudform"
 
-cloudform({
+export default cloudform({
     Description: 'My template',
     Parameters: {
         DeployEnv: new StringParameter({

--- a/cli/cloudform.ts
+++ b/cli/cloudform.ts
@@ -2,53 +2,12 @@
 
 import * as fs from 'fs'
 import * as ts from 'typescript'
+import * as path from 'path'
+import { exec } from 'child_process'
 
-function compile(fileName: string, compilerOptions: ts.CompilerOptions) {
-    const servicesHost: ts.LanguageServiceHost = {
-        getScriptFileNames: () => [fileName],
-        getScriptVersion: fileName => "0",
-        getScriptSnapshot: fileName => {
-            if (!fs.existsSync(fileName)) {
-                return undefined;
-            }
+const templatePath = process.argv[2]
 
-            return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName).toString());
-        },
-        getCurrentDirectory: () => process.cwd(),
-        getCompilationSettings: () => compilerOptions,
-        getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
-        fileExists: ts.sys.fileExists,
-        readFile: ts.sys.readFile,
-        readDirectory: ts.sys.readDirectory,
-    };
-
-    const services = ts.createLanguageService(servicesHost, ts.createDocumentRegistry())
-    const output = services.getEmitOutput(fileName)
-
-    if (output.emitSkipped) {
-        let allDiagnostics = services.getCompilerOptionsDiagnostics()
-            .concat(services.getSyntacticDiagnostics(fileName))
-            .concat(services.getSemanticDiagnostics(fileName))
-
-        allDiagnostics.forEach(diagnostic => {
-            let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
-            if (diagnostic.file) {
-                let {line, character} = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!)
-                console.warn(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`)
-            } else {
-                console.warn(`${message}`)
-            }
-        })
-
-        process.exit(1)
-    } else {
-        console.log(eval(output.outputFiles[0].text))
-    }
-}
-
-const path = process.argv[2]
-
-if (!path || path.startsWith('-')) {
+if (!templatePath || templatePath.startsWith('-')) {
     console.warn(`cloudform - TypeScript-based imperative way to define AWS CloudFormation templates
 
 usage: cloudform <path>
@@ -59,14 +18,14 @@ example: cloudform aws/template.ts > generated.template`)
 }
 
 // console.info(`Compiling AWS CloudForm template from ${process.argv[2]}...`)
-
-compile(path, {
-    noEmitOnError: true,
-    noImplicitAny: true,
-    lib: [
-        "lib.es2015.d.ts",
-        "lib.es2016.array.include.d.ts"
-    ],
-    target: ts.ScriptTarget.ES2015,
-    module: ts.ModuleKind.CommonJS
+exec(`$(npm bin)/ts-node -e "import t from '${path.resolve(templatePath)}'; console.log(t)"`, (err, stdout, stderr) => {
+  if(err) {
+    console.error(err)
+    return
+  }
+  if(stderr) {
+    console.error(stderr)
+    return
+  }
+  console.log(stdout)
 })

--- a/dist/cli/cloudform.js
+++ b/dist/cli/cloudform.js
@@ -1,49 +1,10 @@
 #!/usr/bin/env node
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const fs = require("fs");
-const ts = require("typescript");
-function compile(fileName, compilerOptions) {
-    const servicesHost = {
-        getScriptFileNames: () => [fileName],
-        getScriptVersion: fileName => "0",
-        getScriptSnapshot: fileName => {
-            if (!fs.existsSync(fileName)) {
-                return undefined;
-            }
-            return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName).toString());
-        },
-        getCurrentDirectory: () => process.cwd(),
-        getCompilationSettings: () => compilerOptions,
-        getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
-        fileExists: ts.sys.fileExists,
-        readFile: ts.sys.readFile,
-        readDirectory: ts.sys.readDirectory,
-    };
-    const services = ts.createLanguageService(servicesHost, ts.createDocumentRegistry());
-    const output = services.getEmitOutput(fileName);
-    if (output.emitSkipped) {
-        let allDiagnostics = services.getCompilerOptionsDiagnostics()
-            .concat(services.getSyntacticDiagnostics(fileName))
-            .concat(services.getSemanticDiagnostics(fileName));
-        allDiagnostics.forEach(diagnostic => {
-            let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-            if (diagnostic.file) {
-                let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
-                console.warn(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
-            }
-            else {
-                console.warn(`${message}`);
-            }
-        });
-        process.exit(1);
-    }
-    else {
-        console.log(eval(output.outputFiles[0].text));
-    }
-}
-const path = process.argv[2];
-if (!path || path.startsWith('-')) {
+const path = require("path");
+const child_process_1 = require("child_process");
+const templatePath = process.argv[2];
+if (!templatePath || templatePath.startsWith('-')) {
     console.warn(`cloudform - TypeScript-based imperative way to define AWS CloudFormation templates
 
 usage: cloudform <path>
@@ -53,13 +14,14 @@ example: cloudform aws/template.ts > generated.template`);
     process.exit(1);
 }
 // console.info(`Compiling AWS CloudForm template from ${process.argv[2]}...`)
-compile(path, {
-    noEmitOnError: true,
-    noImplicitAny: true,
-    lib: [
-        "lib.es2015.d.ts",
-        "lib.es2016.array.include.d.ts"
-    ],
-    target: ts.ScriptTarget.ES2015,
-    module: ts.ModuleKind.CommonJS
+child_process_1.exec(`$(npm bin)/ts-node -e "import t from '${path.resolve(templatePath)}'; console.log(t)"`, (err, stdout, stderr) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    if (stderr) {
+        console.error(stderr);
+        return;
+    }
+    console.log(stdout);
 });

--- a/example/config.ts
+++ b/example/config.ts
@@ -1,0 +1,5 @@
+export const NetworkingConfig = {
+    VPC: {
+        CIDR: '10.0.0.0/16'
+    }
+}

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,14 +1,9 @@
 import cloudform, {Fn, Refs, EC2, StringParameter, ResourceTag} from ".." // you should import from cloudform here instead
-
-const NetworkingConfig = {
-    VPC: {
-        CIDR: '10.0.0.0/16'
-    }
-}
+import {NetworkingConfig} from './config'
 
 const DeployEnv = Fn.Ref('DeployEnv')
 
-cloudform({
+export default cloudform({
     Description: 'My template',
     Parameters: {
         DeployEnv: new StringParameter({

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "1.9.1"
       }
@@ -21,14 +20,12 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "chalk": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
       "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
@@ -39,7 +36,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -47,14 +43,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "encoding": {
       "version": "0.1.12",
@@ -68,14 +62,12 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -98,20 +90,17 @@
     "make-error": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
-      "dev": true
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
     },
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -119,8 +108,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -137,14 +125,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
       "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
-      "dev": true,
       "requires": {
         "source-map": "0.6.1"
       }
@@ -153,7 +139,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
       "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-      "dev": true,
       "requires": {
         "has-flag": "3.0.0"
       }
@@ -162,7 +147,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
       "integrity": "sha512-XK7QmDcNHVmZkVtkiwNDWiERRHPyU8nBqZB1+iv2UhOG0q3RQ9HsZ2CMqISlFbxjrYFGfG2mX7bW4dAyxBVzUw==",
-      "dev": true,
       "requires": {
         "arrify": "1.0.1",
         "chalk": "2.3.2",
@@ -182,8 +166,7 @@
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-      "dev": true
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudform",
-  "version": "0.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,53 @@
       "version": "8.0.53",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
       "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ=="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -17,6 +64,18 @@
       "requires": {
         "iconv-lite": "0.4.19"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -36,6 +95,35 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
+    "make-error": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -46,10 +134,56 @@
         "is-stream": "1.1.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
+      "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
+      }
+    },
+    "supports-color": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "ts-node": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
+      "integrity": "sha512-XK7QmDcNHVmZkVtkiwNDWiERRHPyU8nBqZB1+iv2UhOG0q3RQ9HsZ2CMqISlFbxjrYFGfG2mX7bW4dAyxBVzUw==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "2.3.2",
+        "diff": "3.5.0",
+        "make-error": "1.3.4",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.4",
+        "yn": "2.0.0"
+      }
+    },
     "typescript": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
       "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE="
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "lodash": "^4.17.4",
-    "node-fetch": "^1.7.3"
+    "node-fetch": "^1.7.3",
+    "ts-node": "^5.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "dependencies": {
     "@types/node": "^8.0.53",
-    "typescript": "^2.6.1"
+    "typescript": "^2.6.1",
+    "ts-node": "^5.0.1"
   },
   "devDependencies": {
     "lodash": "^4.17.4",
-    "node-fetch": "^1.7.3",
-    "ts-node": "^5.0.1"
+    "node-fetch": "^1.7.3"
   }
 }


### PR DESCRIPTION
This is breaking change request.

### Motivation

I read [this blog post](https://brightinventions.pl/blog/aws-cloudformation-patterns-practices-cloudform/) and try `Split into multiple files` entry.
But, I did not go well ( reproduced repository: https://github.com/sisisin-sandbox/cloudform-split-files )

I read `cli/cloudform.ts`, I found `cloudform.ts` doesn't have module resolution mechanism for executing splitted files.
So, I create this Pull Request.

### My tests

```bash
$ npm run build
$ node ./dist/cli/cloudform.js ./example/example.ts
```

Thank you.