### PR TITLE
Move exports to cloudform-types, re-export from cloudform

### DIFF
--- a/packages/cloudform-types/index.d.ts
+++ b/packages/cloudform-types/index.d.ts
@@ -1,0 +1,10 @@
+import Template from "./types/template";
+export declare type Template = Template;
+import * as _Fn from './types/functions';
+export declare const Fn: typeof _Fn;
+import * as _Refs from './types/refs';
+export declare const Refs: typeof _Refs;
+export * from './types/index';
+export * from './types/dataTypes';
+export * from './types/resource';
+export * from './types/parameter';

--- a/packages/cloudform-types/index.js
+++ b/packages/cloudform-types/index.js
@@ -1,0 +1,13 @@
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+const _Fn = require("./types/functions");
+exports.Fn = _Fn;
+const _Refs = require("./types/refs");
+exports.Refs = _Refs;
+__export(require("./types/index"));
+__export(require("./types/dataTypes"));
+__export(require("./types/resource"));
+__export(require("./types/parameter"));

--- a/packages/cloudform-types/index.ts
+++ b/packages/cloudform-types/index.ts
@@ -1,0 +1,13 @@
+import Template from "./types/template"
+export type Template = Template
+
+import * as _Fn from './types/functions'
+export const Fn = _Fn
+
+import * as _Refs from './types/refs'
+export const Refs = _Refs
+
+export * from './types/index'
+export * from './types/dataTypes'
+export * from './types/resource'
+export * from './types/parameter'

--- a/packages/cloudform-types/package-lock.json
+++ b/packages/cloudform-types/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudform-types",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cloudform/index.js
+++ b/packages/cloudform/index.js
@@ -3,14 +3,7 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-const _Fn = require("cloudform-types/types/functions");
-exports.Fn = _Fn;
-const _Refs = require("cloudform-types/types/refs");
-exports.Refs = _Refs;
-__export(require("cloudform-types/types/index"));
-__export(require("cloudform-types/types/dataTypes"));
-__export(require("cloudform-types/types/resource"));
-__export(require("cloudform-types/types/parameter"));
+__export(require("cloudform-types"));
 function cloudform(template) {
     return JSON.stringify(template, undefined, 2);
 }

--- a/packages/cloudform/index.ts
+++ b/packages/cloudform/index.ts
@@ -1,16 +1,5 @@
-import Template from "cloudform-types/types/template"
-export type Template = Template
-
-import * as _Fn from 'cloudform-types/types/functions'
-export const Fn = _Fn
-
-import * as _Refs from 'cloudform-types/types/refs'
-export const Refs = _Refs
-
-export * from 'cloudform-types/types/index'
-export * from 'cloudform-types/types/dataTypes'
-export * from 'cloudform-types/types/resource'
-export * from 'cloudform-types/types/parameter'
+import { Template } from 'cloudform-types'
+export * from 'cloudform-types'
 
 export default function cloudform(template: Template) {
     return JSON.stringify(template, undefined, 2)

--- a/packages/cloudform/package-lock.json
+++ b/packages/cloudform/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudform",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -60,13 +60,9 @@
       }
     },
     "cloudform-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cloudform-types/-/cloudform-types-3.0.0.tgz",
-      "integrity": "sha512-bK3gQs1PajHOBnSW9/EnEPi4KePAlztpvu2Vv9fgcd9kTQUz1Lia9NubIu2tLI0906Tuj+Gr99yK7wNXr9rdmA==",
-      "requires": {
-        "ts-node": "5.0.1",
-        "typescript": "2.9.2"
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cloudform-types/-/cloudform-types-3.1.0.tgz",
+      "integrity": "sha512-b1WzGxg9G4K5slaQMKoBPvfaKYo+6spMN8FVix/XmxfjKjQr4+ESLMxtQHXZEJ9PQ28YF2Z/SDBmbUNO9NLhyg=="
     },
     "color-convert": {
       "version": "1.9.3",


### PR DESCRIPTION
This allows imports from `cloudform-types` to be exactly like from `cloudform`.
`cloudform` exports stay the same.