### PR TITLE
Forward or emit proper exit code

### DIFF
--- a/packages/cloudform/cli/cloudform.ts
+++ b/packages/cloudform/cli/cloudform.ts
@@ -60,18 +60,18 @@ const resolvedTemplatePath = path.resolve(options.templatePath!)
 exec('npm bin', (err, npmBin) => {
     if (err) {
         console.error(err)
-        return
+        process.exit(err.code)
     }
 
     const tsNodePath = path.join(npmBin.trim(), 'ts-node')
     exec(`${tsNodePath} -e "import t from '${resolvedTemplatePath}'; console.log(t)"`, {maxBuffer: 1024 * 1024 * 5}, (err, template, stderr) => {
         if (err) {
             console.error(err)
-            return
+            process.exit(err.code)
         }
         if (stderr) {
             console.error(stderr)
-            return
+            process.exit(1)
         }
 
         if (options.shouldMinify) {


### PR DESCRIPTION
1. If the executed command errors, `child_process.exec` returns the its code, so it seems to make sense to forward it.

2. When there is something in `stderr`, it seems to make sense to exit with non-zero code.