### PR TITLE
Remove unnecessary main from package.json (fixes #70, nodejs16 compat)

### DIFF
--- a/packages/cloudform/package.json
+++ b/packages/cloudform/package.json
@@ -2,7 +2,6 @@
   "name": "cloudform",
   "version": "7.4.0",
   "description": "TypeScript-based imperative way to define AWS CloudFormation templates",
-  "main": "packages/cloudform/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bright/cloudform.git"


### PR DESCRIPTION
cloudform stopped working when we upgraded to node16. I know there are better tools out there now, but we have a pretty involved ts declaration of our infra based on this tool, so this worked around the problem in a much quicker way than redoing our infra declaration. Thank you! 